### PR TITLE
Preact-cli next support

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -31,13 +31,14 @@
         "build/*"
     ],
     "devDependencies": {
+        "@types/webpack-env": "^1.13.9",
         "@types/jest": "^23.3.10",
         "husky": "^1.2.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^23.6.0",
         "lint-staged": "^8.1.0",
         "per-env": "^1.0.2",
-        "preact-cli": "^2.2.1",
+        "preact-cli": "^3.0.0-next.19",
         "preact-render-spy": "^1.3.0",
         "prettier": "^1.15.3",
         "ts-jest": "^23.10.5",
@@ -48,7 +49,8 @@
         "tslint-eslint-rules": "^5.4.0",
         "tslint-react": "^3.6.0",
         "typescript": "^3.2.1",
-        "typings-for-css-modules-loader": "^1.7.0"
+        "typings-for-css-modules-loader": "^1.7.0",
+        "css-loader": "^1.0.1"
     },
     "dependencies": {
         "preact": "^8.3.1",

--- a/template/preact.config.js
+++ b/template/preact.config.js
@@ -14,11 +14,6 @@ export default function(config, env, helpers) {
         });
     });
 
-    config.module.loaders.push({
-        test: /\.[tj]sx?$/,
-        loader: "ts-loader"
-    });
-
     // Use any `index` file, not just index.js
     config.resolve.alias["preact-cli-entrypoint"] = resolve(
         process.cwd(),


### PR DESCRIPTION
Fix up some dependencies for `preact-cli@next`.

Notably we need to depend on `"css-loader": "^1.0.1"`, due to https://github.com/Jimdo/typings-for-css-modules-loader/issues/89.

`@types/webpack-env` prevents vscode from whining about the use of `module` in `app.tsx`.