### PR TITLE
enable husky

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -11,18 +11,16 @@
         "serve": "preact build && sirv build --port 8080 --cors --single",
         "dev": "preact watch",
         "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
-        "test": "jest ./tests",
-        "precommit": "lint-staged"
+        "test": "jest ./tests"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "lint-staged"
+        }
     },
     "lint-staged": {
-        "*.{css,md,scss}": [
-            "prettier --write",
-            "git add"
-        ],
-        "*.{js,jsx,ts,tsx}": [
-            "eslint --fix",
-            "git add"
-        ]
+        "*.{css,md,scss}": "prettier --write",
+        "*.{js,jsx,ts,tsx}": "eslint --fix"
     },
     "eslintIgnore": [
         "build/*"


### PR DESCRIPTION
Update the old `husky` setting and re-enable `husky`.

See also:
- https://github.com/okonet/lint-staged/tree/v10.0.7#examples
- https://github.com/typicode/husky/tree/v4.2.1#install