### PR TITLE
Removal of per-env as per #1062

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,7 @@
     "version": "0.0.0",
     "license": "MIT",
     "scripts": {
-        "start": "per-env",
+        "start": "preact watch",
         "start:production": "npm run -s serve",
         "start:development": "npm run -s dev",
         "build": "preact build",
@@ -46,7 +46,6 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^25.1.0",
         "lint-staged": "^10.0.7",
-        "per-env": "^1.0.2",
         "preact-cli": "^3.0.0-next.19",
         "preact-render-spy": "^1.3.0",
         "prettier": "^1.19.1",

--- a/template/package.json
+++ b/template/package.json
@@ -4,11 +4,8 @@
     "version": "0.0.0",
     "license": "MIT",
     "scripts": {
-        "start": "preact watch",
-        "start:production": "npm run -s serve",
-        "start:development": "npm run -s dev",
         "build": "preact build",
-        "serve": "preact build && sirv build --port 8080 --cors --single",
+        "serve": "sirv build --port 8080 --cors --single",
         "dev": "preact watch",
         "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
         "test": "jest ./tests"


### PR DESCRIPTION
Per-env is broken on windows and as such users who follow the preact-cli instructions are unable to start the dev environment. Based on the discussion of #1062 it was advised by @ForsakenHarmony to remove the per-env dependency.