### PR TITLE
fix: do not convert style import

### DIFF
--- a/template/jest.config.js
+++ b/template/jest.config.js
@@ -23,7 +23,6 @@ module.exports = {
     moduleNameMapper: {
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/tests/__mocks__/fileMock.js",
         "\\.(css|less|scss)$": "identity-obj-proxy",
-        "^./style$": "identity-obj-proxy",
         "^preact$": "<rootDir>/node_modules/preact/dist/preact.min.js",
         "^react$": "preact-compat",
         "^react-dom$": "preact-compat",


### PR DESCRIPTION
## Background

`moduleNameMapper` in `jest.config.js` affects third-party libraries as well in addition to `./src/styles` in this template. It causes terrible phenomena like JavaScript files in third-party libraries are converted into a plain object, not a module.

In my case, I tried to import `@material-ui/core/Button` in my project. Then, `import styles from "./styles"` [here](https://github.com/mui-org/material-ui/blob/02d45cca0f8a24ff8c97396b06201aa97faac3d2/packages/material-ui-system/src/borders.js#L1) is converted into empty object (`{}`). Not like this: `{ default: [Function ... ] }`.

## Proposed solution

Just removing `moduleNameMapper` config for styles in `jest.config.js`. It should work without this config since css files are converted by another configuration.

---

I don't know my proposal makes sense, please give me feedback if there is a better way. Thanks for providing us an awesome library. 👍 