### PR TITLE
Update testing infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,16 @@ your machine it will start the development server on a random port.
 
 -   `npm run lint`: Pass TypeScript files using ESLint
 
--   `npm run test`: Run Jest and
-    [`preact-render-spy`](https://github.com/mzgoddard/preact-render-spy) for
+-   `npm run test`: Run Jest and Enzyme with
+    [`enzyme-adapter-preact-pure`](https://github.com/preactjs/enzyme-adapter-preact-pure) for
     your tests
 
 ### How to Test
 
-The `typescript` template provides a basic test setup with Jest and
-[`preact-render-spy`](https://github.com/mzgoddard/preact-render-spy). You are
-free to change preact-render-spy with any other assertion library. The advantage
-of it is that it supports a similar terminology and feature set as the Enzyme
-library for testing React applications.
+The `typescript` template provides a basic test setup with Jest, Enzyme and
+[`enzyme-adapter-preact-pure`](https://github.com/preactjs/enzyme-adapter-preact-pure).
+You are free to change Enzyme with any other testing library
+(eg. [Preact Testing Library](https://testing-library.com/docs/preact-testing-library/intro)).
 
 You can run all additional Jest CLI commands with the `npm run test` command as
 described in the

--- a/template/README.md
+++ b/template/README.md
@@ -11,7 +11,9 @@
 
 *   `npm run lint`: Pass TypeScript files using TSLint
 
-*   `npm run test`: Run Jest and [`preact-render-spy`](https://github.com/mzgoddard/preact-render-spy) for your tests
+*   `npm run test`: Run Jest and Enzyme with
+    [`enzyme-adapter-preact-pure`](https://github.com/preactjs/enzyme-adapter-preact-pure) for
+    your tests
 
 
 For detailed explanation on how things work, checkout the [CLI Readme](https://github.com/developit/preact-cli/blob/master/README.md).

--- a/template/jest.config.js
+++ b/template/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
     testURL: "http://localhost:8080",
     moduleNameMapper: {
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/tests/__mocks__/fileMock.js",
-        "^create-react-class$": "preact-compat/lib/create-react-class",
         "^react-addons-css-transition-group$": "preact-css-transition-group"
     }
 }

--- a/template/jest.config.js
+++ b/template/jest.config.js
@@ -7,6 +7,5 @@ module.exports = {
     testURL: "http://localhost:8080",
     moduleNameMapper: {
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/tests/__mocks__/fileMock.js",
-        "^react-addons-css-transition-group$": "preact-css-transition-group"
     }
 }

--- a/template/jest.config.js
+++ b/template/jest.config.js
@@ -1,26 +1,10 @@
 module.exports = {
-    transform: {
-        "^.+\\.tsx?$": "ts-jest"
-    },
-    verbose: true,
+    preset: "jest-preset-preact",
     setupFiles: [
         "<rootDir>/src/tests/__mocks__/setupTests.js",
         "<rootDir>/src/tests/__mocks__/browserMocks.js"
     ],
     testURL: "http://localhost:8080",
-    moduleFileExtensions: [
-        "js",
-        "jsx",
-        "ts",
-        "tsx"
-    ],
-    moduleDirectories: [
-        "node_modules"
-    ],
-    testMatch: [
-        "**/__tests__/**/*.[jt]s?(x)",
-        "**/?(*.)(spec|test).[jt]s?(x)"
-    ],
     moduleNameMapper: {
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/tests/__mocks__/fileMock.js",
         "\\.(css|less|scss)$": "identity-obj-proxy",

--- a/template/jest.config.js
+++ b/template/jest.config.js
@@ -7,11 +7,6 @@ module.exports = {
     testURL: "http://localhost:8080",
     moduleNameMapper: {
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/tests/__mocks__/fileMock.js",
-        "\\.(css|less|scss)$": "identity-obj-proxy",
-        "^./style$": "identity-obj-proxy",
-        "^preact$": "<rootDir>/node_modules/preact/dist/preact.min.js",
-        "^react$": "preact-compat",
-        "^react-dom$": "preact-compat",
         "^create-react-class$": "preact-compat/lib/create-react-class",
         "^react-addons-css-transition-group$": "preact-css-transition-group"
     }

--- a/template/jest.config.js
+++ b/template/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
     },
     verbose: true,
     setupFiles: [
+        "<rootDir>/src/tests/__mocks__/setupTests.js",
         "<rootDir>/src/tests/__mocks__/browserMocks.js"
     ],
     testURL: "http://localhost:8080",

--- a/template/jest.config.js
+++ b/template/jest.config.js
@@ -6,6 +6,6 @@ module.exports = {
     ],
     testURL: "http://localhost:8080",
     moduleNameMapper: {
-        "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/tests/__mocks__/fileMock.js",
+        "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/tests/__mocks__/fileMocks.js",
     }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -30,11 +30,14 @@
         "preact-router": "^3.2.1"
     },
     "devDependencies": {
+        "@types/enzyme": "^3.10.5",
         "@types/jest": "^25.1.2",
         "@types/webpack-env": "^1.15.1",
         "@typescript-eslint/eslint-plugin": "^2.25.0",
         "@typescript-eslint/parser": "^2.25.0",
         "css-loader": "^1.0.1",
+        "enzyme": "^3.11.0",
+        "enzyme-adapter-preact-pure": "^2.2.0",
         "eslint": "^6.8.0",
         "eslint-config-prettier": "^6.10.1",
         "eslint-plugin-prettier": "^3.1.2",
@@ -45,7 +48,6 @@
         "jest": "^25.1.0",
         "lint-staged": "^10.0.7",
         "preact-cli": "^3.0.0-next.19",
-        "preact-render-spy": "^1.3.0",
         "prettier": "^1.19.1",
         "sirv-cli": "^1.0.0-next.3",
         "ts-jest": "^25.2.0",

--- a/template/package.json
+++ b/template/package.json
@@ -46,6 +46,7 @@
         "husky": "^4.2.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^25.1.0",
+        "jest-preset-preact": "^1.0.0",
         "lint-staged": "^10.0.7",
         "preact-cli": "^3.0.0-next.19",
         "prettier": "^1.19.1",

--- a/template/package.json
+++ b/template/package.json
@@ -44,15 +44,12 @@
         "eslint-plugin-react": "^7.19.0",
         "eslint-plugin-react-hooks": "^3.0.0",
         "husky": "^4.2.1",
-        "identity-obj-proxy": "^3.0.0",
         "jest": "^25.1.0",
         "jest-preset-preact": "^1.0.0",
         "lint-staged": "^10.0.7",
         "preact-cli": "^3.0.0-next.19",
         "prettier": "^1.19.1",
         "sirv-cli": "^1.0.0-next.3",
-        "ts-jest": "^25.2.0",
-        "ts-loader": "^6.2.1",
         "typescript": "^3.7.5",
         "typings-for-css-modules-loader": "^1.7.0"
     }

--- a/template/src/declaration.d.ts
+++ b/template/src/declaration.d.ts
@@ -1,4 +1,0 @@
-import { JSX } from "preact";
-
-export = JSX;
-export as namespace JSX;

--- a/template/src/tests/__mocks__/setupTests.js
+++ b/template/src/tests/__mocks__/setupTests.js
@@ -1,0 +1,6 @@
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-preact-pure";
+
+configure({
+    adapter: new Adapter()
+});

--- a/template/src/tests/declarations.d.ts
+++ b/template/src/tests/declarations.d.ts
@@ -1,0 +1,3 @@
+// Enable enzyme adapter's integration with TypeScript
+// See: https://github.com/preactjs/enzyme-adapter-preact-pure#usage-with-typescript
+/// <reference types="enzyme-adapter-preact-pure" />

--- a/template/src/tests/header.test.tsx
+++ b/template/src/tests/header.test.tsx
@@ -1,6 +1,6 @@
 import { h } from "preact";
-// See: https://github.com/mzgoddard/preact-render-spy
-import { shallow } from "preact-render-spy";
+// See: https://github.com/preactjs/enzyme-adapter-preact-pure
+import { shallow } from "enzyme";
 import Header from "../components/header";
 
 describe("Initial Test of the Header", () => {


### PR DESCRIPTION
### Description

This PR changes the setup & used dependencies of the testing infrastructure.
~Creating a DRAFT for now, since I still need to modify `README.md` file, but feel free to comment on everything else.~

First of all, the manual Jest configuration has been replaced with `jest-preset-preact`, similar to the [`default`](https://github.com/preactjs-templates/default) template. As far as I could see, the latest `preact-cli` (3.+) supports TypeScript out of the box, so there's no longer a need to re-configure it in this template. I've also took the liberty of removing two module mappers that looked out of place (`^./style$` and `^react-addons-css-transition-group$`, they both look "project-specific") and one outdated entry (`^create-react-class$`, which pointed to Preact 8's compat package).

Next, `preact-render-spy` has been removed and now Enzyme is being used instead. The previously used library is outdated, does not support Preact 10 (there's a fork that supposedly supports it though, but apparently there are still some problems yet to be resolved), and this change brings this template closer to the default one (which uses enzyme as well). With the current version of the template, the only provided test fails with TypeError. This problem is fixed by this PR.

Last, but not least, I've removed the root `declaration.d.ts` file which apparently causes the entire TypeScript's language server to crash (see https://github.com/preactjs/preact-cli/issues/1030 and https://github.com/preactjs/preact-cli/issues/1030). As I've commented here: https://github.com/preactjs/preact-cli/issues/1030#issuecomment-624753598
I believe that this declaration is no longer needed, but to be honest, I'm not 100% sure about that. So far, I haven't noticed anything being broken due to this declaration's removal, but if there's anyone with any knowledge about this file's origin, please take a look and see if I'm right or not. This PR **can** be merged without this file being removed, however I'll have to modify the PR and provide a workaround for Enzyme's typings (I can add an empty module declaration, which won't make using enzyme type-safe, but at least the tests won't complaing about missing types for `enzyme` import).

For the moment, I've set up a temporary template repo here: https://github.com/mdziekon/preactjs-templates-typescript-test
If anyone wants to test this on their own, you should be able to use it until this PR gets closed.

### Changelog
- [x] Modify Jest's config and use `jest-preset-preact`
- [x] Replace `preact-render-spy` with `enzyme` and `enzyme-adapter-preact-pure`
- [x] Remove `declaration.d.ts` to prevent tsserver crashes
- [x] Modify `README.md` to reflect these changes in the `How to Test` section
- [x] Remove unused dependencies
- [x] Fix file mocks mapper path (see: https://github.com/preactjs-templates/default/pull/25)