### PR TITLE
fix(linter): Fixing lint command if ran with Yarn

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -7,7 +7,7 @@
         "build": "preact build",
         "serve": "sirv build --port 8080 --cors --single",
         "dev": "preact watch",
-        "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
+        "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
         "test": "jest ./tests"
     },
     "husky": {


### PR DESCRIPTION
Fix for #24 

Lint command will not work when ran by Yarn, but this resolves the issue. 