### PR TITLE
Add support for tsconfig.json 'baseUrl' and 'paths' fields

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -27,7 +27,8 @@
         "preact-jsx-chai": "^3.0.0",
         "preact-markup": "^2.0.0",
         "preact-render-to-string": "^5.1.4",
-        "preact-router": "^3.2.1"
+        "preact-router": "^3.2.1",
+        "tsconfig-paths-webpack-plugin": "^3.2.0"
     },
     "devDependencies": {
         "@types/jest": "^25.1.2",

--- a/template/preact.config.js
+++ b/template/preact.config.js
@@ -1,4 +1,5 @@
 import { resolve } from "path";
+import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin'
 
 export default {
     /**
@@ -23,6 +24,22 @@ export default {
                 silent: true
             });
         });
+
+        // Add TsconfigPathsPlugin for webpack
+        // This allows webpack to resolve your imports whose location depends
+        // on the `baseUrl` and `paths` fields of your `tsconfig.json`
+        // https://github.com/dividab/tsconfig-paths-webpack-plugin#tsconfig-paths-webpack-plugin
+        config.resolve.plugins = [
+            ...(config.resolve.plugins || []),
+            new TsconfigPathsPlugin({
+                // We use `config.resolve.extensions` to load the same extensions
+                // as webpack already does. If you are to edit this property,
+                // do it before this call if you want TsconfigPathsPlugin
+                // to beneficiate from it
+                extensions: config.resolve.extensions
+            })
+        ]
+      
 
         // Use any `index` file, not just index.js
         config.resolve.alias["preact-cli-entrypoint"] = resolve(

--- a/template/preact.config.js
+++ b/template/preact.config.js
@@ -39,7 +39,6 @@ export default {
                 extensions: config.resolve.extensions
             })
         ]
-      
 
         // Use any `index` file, not just index.js
         config.resolve.alias["preact-cli-entrypoint"] = resolve(


### PR DESCRIPTION
This PR add [dividab/tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin) to webpack.

This allows webpack to resolve imports whose location depends on the `baseUrl` and `paths` fields of the `tsconfig.json`

First mentioned here: #28 