### PR TITLE
Fixes "The file does not match your project config: preact.config.js" eslint error

### DIFF
--- a/template/tsconfig.eslint.json
+++ b/template/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 // see https://github.com/typescript-eslint/typescript-eslint/issues/890
 {
     "extends": "./tsconfig.json",
-    "include": ["src/**/*"]
+    "include": ["*.config.js", "src/**/*"]
 }


### PR DESCRIPTION
This PR fix this eslint error:

```
husky > pre-commit (node v12.10.0)
✔ Preparing...
✔ Hiding unstaged changes to partially staged files...
⚠ Running tasks...
  ↓ No staged files match *.{css,md,scss} [SKIPPED]
  ❯ Running tasks for *.{js,jsx,ts,tsx}
    ✖ eslint --fix [FAILED]
↓ Skipped because of errors from tasks. [SKIPPED]
↓ Skipped because of errors from tasks. [SKIPPED]
✔ Reverting to original state because of errors...
✔ Cleaning up...

✖ eslint --fix:

/Users/antoine/Workspaces/typescript/template/preact.config.js
  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: preact.config.js.
The file must be included in at least one of the projects provided

✖ 1 problem (1 error, 0 warnings)

husky > pre-commit hook failed (add --no-verify to bypass)
```