### PR TITLE
remove modules: commonjs from babelrc

### DIFF
--- a/template/src/.babelrc
+++ b/template/src/.babelrc
@@ -1,5 +1,5 @@
 {
     "presets": [ 
-        ["preact-cli/babel", { "modules": "commonjs" }]
+        "preact-cli/babel"
     ]
 }


### PR DESCRIPTION
Fixes issue described in https://github.com/preactjs/preact-cli/issues/1215#issuecomment-642015008

Since we introduced custom babel configs in rc.10