### PR TITLE
fix: add ts-jest and change jest.config.js

### DIFF
--- a/template/jest.config.js
+++ b/template/jest.config.js
@@ -1,11 +1,15 @@
 module.exports = {
     preset: "jest-preset-preact",
+    transform: {
+        "^.+\\.tsx?$": "ts-jest"
+    },
     setupFiles: [
         "<rootDir>/src/tests/__mocks__/setupTests.js",
         "<rootDir>/src/tests/__mocks__/browserMocks.js"
     ],
     testURL: "http://localhost:8080",
     moduleNameMapper: {
-        "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/tests/__mocks__/fileMocks.js",
+        "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+            "<rootDir>/src/tests/__mocks__/fileMocks.js"
     }
-}
+};

--- a/template/package.json
+++ b/template/package.json
@@ -51,6 +51,7 @@
         "preact-cli": "^3.0.0",
         "prettier": "^1.19.1",
         "sirv-cli": "^1.0.0-next.3",
+        "ts-jest": "^26.1.3",
         "typescript": "^3.7.5"
     }
 }


### PR DESCRIPTION
As stated in #36 the current jest config is not working. Implemented the solution found in [`widget-typescript`](https://github.com/preactjs-templates/widget-typescript/blob/master/template/jest.config.js).

Changes:

- Installed `ts-jest 26.1.3`
- Changed `jest.config.js` to use `ts-jest` on `.ts` and `.tsx` files