### PR TITLE
docs(readme): Correcting CLI usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 ## Usage
 
 ```bash
-$ npm install -g preact-cli
-$ preact create typescript my-project
+$ npx preact-cli create typescript my-project
 $ cd my-project
 $ npm install
 $ npm run dev


### PR DESCRIPTION
## Description

Corrects usage information to use NPX rather than install the Preact CLI globally

## Reason for Change

The CLI's documentation had an update and now [the recommended way to use it is via NPX](https://github.com/preactjs/preact-cli#usage). This template should say the same.