### PR TITLE
refactor(tsconfig): Adding skipLibCheck

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -34,6 +34,7 @@
 
         /* Module Resolution Options */
         "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        "esModuleInterop": true,                  /* */
         // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
         // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
@@ -51,7 +52,9 @@
         /* Experimental Options */
         // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
         // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-        "esModuleInterop": true
+
+        /* Advanced Options */
+        "skipLibCheck": true                      /* Skip type checking of declaration files. */
     },
     "include": ["src/**/*.tsx", "src/**/*.ts"]
 }


### PR DESCRIPTION
I was having a browse through Preact's site when I came across the [TS preact/compat section](https://preactjs.com/guide/v10/getting-started#typescript-preactcompat-configuration). It suggests setting `"skipLibChecks"` to `true` to ensure support for the wider ecosystem of React libraries, but we don't have that enabled here.

The option was added to the template's `tsconfig.json` file under "Advanced Options" as that is the header it is under on the [TSConfig reference page](https://www.typescriptlang.org/tsconfig). The [description of the option](https://www.typescriptlang.org/tsconfig#skipLibCheck) was taken right from the TSConfig reference page.

I also moved the `"esModuleInterop"` option up into the "Module Resolution Options" section as it was [out out place](https://www.typescriptlang.org/tsconfig#esModuleInterop). 