### PR TITLE
Set noEmit: true to prevent accidental build artifacts in "src/"

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -14,7 +14,7 @@
         // "outDir": "./",                        /* Redirect output structure to the directory. */
         // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
         // "removeComments": true,                /* Do not emit comments to output. */
-        // "noEmit": true,                        /* Do not emit outputs. */
+        "noEmit": true,                           /* Do not emit outputs. */
         // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
         // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
         // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */


### PR DESCRIPTION
Currently, running `tsc` in the root of the project results in build artifacts (built .js files) being placed in `src/`.

This remedies the behavior and allows users to run `tsc` for manual typechecking independently of the build process.