### PR TITLE
feat: Support custom fragment factories

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -35,7 +35,7 @@
         "jest-preset-preact": "^4.0.2",
         "preact-cli": "^3.0.0",
         "sirv-cli": "^1.0.0-next.3",
-        "typescript": "^3.7.5"
+        "typescript": "^4.5.2"
     },
     "jest": {
         "preset": "jest-preset-preact",

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -8,6 +8,7 @@
         // "checkJs": true,                       /* Report errors in .js files. */
         "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
         "jsxFactory": "h",                        /* Specify the JSX factory function to use when targeting react JSX emit, e.g. React.createElement or h. */
+        "jsxFragmentFactory": "Fragment",         /* Specify the JSX fragment factory function to use when targeting react JSX emit with jsxFactory compiler option is specified, e.g. Fragment. */
         // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
         // "sourceMap": true,                     /* Generates corresponding '.map' file. */
         // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
Closes https://github.com/preactjs/preact-cli/issues/1057

Allows for writing JSX fragments in the shorthand, i.e., `<>...</>`

```
import { Fragment, h } from 'preact';

const MyComponent = () => <></>
```

Config option requires at least TS v4.0.0, hence the dependency version change