### PR TITLE
chore: Removes unnecessary babel config

### DIFF
--- a/template/src/.babelrc
+++ b/template/src/.babelrc
@@ -1,5 +1,0 @@
-{
-    "presets": [ 
-        "preact-cli/babel"
-    ]
-}


### PR DESCRIPTION
This will not get picked up automatically (CLI would only pick it up if it were in the root of the project), and even if it did, it would provide no value.

Right now there's a bit of an issue with setting CLI as a preset (see https://github.com/preactjs/preact-cli/issues/1628#issuecomment-989485192), so even if this were picked up upon, it won't work correctly.

Brought up to me by: https://stackoverflow.com/questions/70474025/styled-jsx-works-inline-but-not-as-module/70477447#70477447

