### PR TITLE
Fixes app -> preact_root id change in style

### DIFF
--- a/template/src/style/index.css
+++ b/template/src/style/index.css
@@ -15,6 +15,6 @@ html, body {
 	box-sizing: border-box;
 }
 
-#app {
+#preact_root {
 	height: 100%;
 }


### PR DESCRIPTION
Hey folks :wave: quick fix here.

We have changed from id `app` to id `preact_root` but forgot to change the CSS accordingly.

See
- https://github.com/preactjs-templates/typescript/issues/55
- https://github.com/preactjs-templates/typescript/pull/56