### PR TITLE
chore: Removing test dir from tsconfig includes and adding paths to preact/compat types 

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -36,8 +36,11 @@
         /* Module Resolution Options */
         "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
         "esModuleInterop": true,                  /* */
-        // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-        // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+        "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+          "react": ["./node_modules/preact/compat"],
+          "react-dom": ["./node_modules/preact/compat"]
+        },
         // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
         // "typeRoots": [],                       /* List of folders to include type definitions from. */
         // "types": [],                           /* Type declaration files to be included in compilation. */
@@ -57,5 +60,5 @@
         /* Advanced Options */
         "skipLibCheck": true                      /* Skip type checking of declaration files. */
     },
-    "include": ["src/**/*", "tests/**/*"]
+    "include": ["src/**/*"]
 }


### PR DESCRIPTION
"Fixes" #71, integrates in the new recommendation from https://github.com/preactjs/preact-www/pull/850