### PR TITLE
chore: Bump deps

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -7,7 +7,7 @@
         "build": "preact build",
         "serve": "sirv build --cors --single",
         "dev": "preact watch",
-        "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
+        "lint": "eslint src",
         "test": "jest ./tests"
     },
     "eslintConfig": {

--- a/template/package.json
+++ b/template/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "scripts": {
         "build": "preact build",
-        "serve": "sirv build --port 8080 --cors --single",
+        "serve": "sirv build --cors --single",
         "dev": "preact watch",
-        "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
+        "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
         "test": "jest ./tests"
     },
     "eslintConfig": {
@@ -18,23 +18,23 @@
         ]
     },
     "dependencies": {
-        "preact": "^10.3.1",
-        "preact-render-to-string": "^5.1.4",
+        "preact": "^10.10.0",
+        "preact-render-to-string": "^5.2.1",
         "preact-router": "^3.2.1"
     },
     "devDependencies": {
-        "@types/enzyme": "^3.10.5",
-        "@types/jest": "^26.0.8",
-        "@typescript-eslint/eslint-plugin": "^2.25.0",
-        "@typescript-eslint/parser": "^2.25.0",
+        "@types/enzyme": "^3.10.12",
+        "@types/jest": "^27.4.1",
+        "@typescript-eslint/eslint-plugin": "^5.30.6",
+        "@typescript-eslint/parser": "^5.30.6",
         "enzyme": "^3.11.0",
-        "enzyme-adapter-preact-pure": "^3.1.0",
-        "eslint": "^6.8.0",
-        "eslint-config-preact": "^1.1.1",
-        "jest": "^27.2.5",
-        "jest-preset-preact": "^4.0.2",
-        "preact-cli": "^3.0.0",
-        "sirv-cli": "^1.0.0-next.3",
+        "enzyme-adapter-preact-pure": "^4.0.1",
+        "eslint": "^8.20.0",
+        "eslint-config-preact": "^1.3.0",
+        "jest": "^27.5.1",
+        "jest-preset-preact": "^4.0.5",
+        "preact-cli": "^3.4.0",
+        "sirv-cli": "^2.0.2",
         "typescript": "^4.5.2"
     },
     "jest": {

--- a/template/package.json
+++ b/template/package.json
@@ -8,7 +8,7 @@
         "serve": "sirv build --cors --single",
         "dev": "preact watch",
         "lint": "eslint src",
-        "test": "jest ./tests"
+        "test": "jest"
     },
     "eslintConfig": {
         "parser": "@typescript-eslint/parser",


### PR DESCRIPTION
Re: https://github.com/preactjs/preact-cli/issues/1712#issuecomment-1187008467

Mostly just bumps deps to latest, but fixes a couple issues relating to the linter:
  1. Existing lint command didn't work in Windows because Windows is silly and doesn't support single quotes across the board. Can simplify by removing glob patterns.
  2. Installation of `eslint-config-jest` (which is used by the preact config) would fail in environments with strict peer deps, as it relies upon a newer version of `@typescript-eslint/eslint-plugin`. Bumping this plugin resolves the issue.